### PR TITLE
Fixed link to mailing list discussion 'How Do I Codesign an App'

### DIFF
--- a/_posts/2016-10-31-this-week-in-livecode-57.markdown
+++ b/_posts/2016-10-31-this-week-in-livecode-57.markdown
@@ -21,7 +21,7 @@ community.  Want something mentioned?  Tweet
 
 ### Interesting discussions
 
-- [How do I codesign an app?](https://www.mail-archive.com/use-livecode@lists.runrev.com/)
+- [How do I codesign an app?]https://www.mail-archive.com/use-livecode@lists.runrev.com/msg79766.html)
 - [Overriding HTTPS certificate verification failure](https://www.mail-archive.com/use-livecode@lists.runrev.com/msg79744.html)
 
 ## Updates in the LiveCode open source project


### PR DESCRIPTION
Fixed a link in this weeks newsletter. Link "How Do I Codesign an App"
originally pointed to the index of the mailing list, now points to the
first discussion in the relevent topic.